### PR TITLE
Fix wrong POST route for creating a new account

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -8,7 +8,7 @@ router.get('/new', (req, res) => {
 })
 
 //Create New Account Item
-router.post('/', (req, res) => {
+router.post('/account', (req, res) => {
     const account = new Account({
         amount: req.body.amount
     })


### PR DESCRIPTION
Die `action` property beim Formular für einen neuen Account ist auf `/account` gesetzt: https://github.com/lofma/kostenrechnung/blob/master/views/account/new.ejs#L3 

Ich bin jetzt einfach mal davon ausgegangen, dass das korrekt ist und hab deshalb die Route hier angepasst.

NB: Nach dem Abspeichern bleibt die Anwendung dann noch stecken weil in der Route `/account` nicht resolved wird.. Aber das überlass ich dir :)